### PR TITLE
iter.go: added return true case after a channel send that does not have a timeout.

### DIFF
--- a/iter.go
+++ b/iter.go
@@ -31,6 +31,7 @@ func (sm *SortedMap) sendRecord(ch chan Record, sendTimeout *time.Duration, i in
 
 	if sendTimeout == nil {
 		ch <- rec
+		return true
 	} else {
 		select {
 		case ch <- rec:


### PR DESCRIPTION
This fixes a bug where the parent function of the sendRecord method would return too early.