### PR TITLE
Removed bool status from IterCh method return values.

### DIFF
--- a/bounds.go
+++ b/bounds.go
@@ -2,7 +2,7 @@ package sortedmap
 
 import "sort"
 
-func (sm *SortedMap) rangeIdxSearch(lowerBound, upperBound interface{}) []int {
+func (sm *SortedMap) boundsIdxSearch(lowerBound, upperBound interface{}) []int {
 
 	if lowerBound == nil || upperBound == nil {
 		return nil

--- a/delete.go
+++ b/delete.go
@@ -28,7 +28,7 @@ func (sm *SortedMap) delete(key interface{}) bool {
 }
 
 func (sm *SortedMap) deleteRange(lowerBound, upperBound interface{}) bool {
-	iterBounds := sm.rangeIdxSearch(lowerBound, upperBound)
+	iterBounds := sm.boundsIdxSearch(lowerBound, upperBound)
 	if len(iterBounds) < 2 {
 		return false
 	}

--- a/iter.go
+++ b/iter.go
@@ -97,7 +97,7 @@ func (params *IterChParams) bounds() []int {
 	}
 }
 
-func (sm *SortedMap) iterCh(params *IterChParams) (<-chan Record, bool) {
+func (sm *SortedMap) iterCh(params *IterChParams) <-chan Record {
 
 	localParams := sm.parseChBoundParams(params)
 	ch := make(chan Record, setBufSize(localParams.BufSize))
@@ -135,7 +135,7 @@ func (sm *SortedMap) iterCh(params *IterChParams) (<-chan Record, bool) {
 		close(ch)
 	}(localParams, ch)
 
-	return ch, true
+	return ch
 }
 
 func (sm *SortedMap) iterFunc(reversed bool, lowerBound, upperBound interface{}, f func(rec *Record) bool) {
@@ -172,16 +172,14 @@ func (sm *SortedMap) iterFunc(reversed bool, lowerBound, upperBound interface{},
 // IterCh returns a channel that sorted records can be read from and processed.
 // This method defaults to the expected behavior of blocking until a read, with no timeout.
 func (sm *SortedMap) IterCh() <-chan Record {
-	rec, _ := sm.iterCh(nil)
-	return rec
+	return sm.iterCh(nil)
 }
 
-// BoundedIterCh returns a channel that sorted records can be read from and processed,
-// and a boolean value that indicates whether or not values in the collection fall between the given bounds.
+// BoundedIterCh returns a channel that sorted records can be read from and processed.
 // BoundedIterCh starts at the lower bound value and sends all values in the collection until reaching the upper bounds value.
 // Sort order is reversed if the reversed argument is set to true.
 // This method defaults to the expected behavior of blocking until a channel send completes, with no timeout.
-func (sm *SortedMap) BoundedIterCh(reversed bool, lowerBound, upperBound interface{}) (<-chan Record, bool) {
+func (sm *SortedMap) BoundedIterCh(reversed bool, lowerBound, upperBound interface{}) <-chan Record {
 	return sm.iterCh(&IterChParams{
 		Reversed: reversed,
 		LowerBound: lowerBound,
@@ -189,12 +187,11 @@ func (sm *SortedMap) BoundedIterCh(reversed bool, lowerBound, upperBound interfa
 	})
 }
 
-// CustomIterCh returns a channel that sorted records can be read from and processed,
-// and a boolean value that indicates whether or not values in the collection fall between the given bounds.
+// CustomIterCh returns a channel that sorted records can be read from and processed.
 // CustomIterCh starts at the lower bound value and sends all values in the collection until reaching the upper bounds value.
 // Sort order is reversed if the reversed argument is set to true.
 // This method defaults to the expected behavior of blocking until a channel send completes, with no timeout.
-func (sm *SortedMap) CustomIterCh(params *IterChParams) (<-chan Record, bool) {
+func (sm *SortedMap) CustomIterCh(params *IterChParams) <-chan Record {
 	return sm.iterCh(params)
 }
 

--- a/iter_test.go
+++ b/iter_test.go
@@ -27,84 +27,73 @@ func TestIterChTimeout(t *testing.T) {
 		t.Fatal(err)
 	}
 	timeout := 1 * time.Microsecond
+	sleepDur := 10 * time.Microsecond
 	params := &IterChParams{SendTimeout: timeout}
 
-	if ch, ok := sm.CustomIterCh(params); ok {
-		for i := 0; i < 5; i++ {
-			time.Sleep(10 * time.Microsecond)
-			rec := <- ch
-			if i > 1 && rec.Key != nil {
-				t.Fatalf("TestCustomIterCh failed: %v: %v", nonNilValErr, rec.Key)
-			}
+	ch := sm.CustomIterCh(params)
+	for i := 0; i < 5; i++ {
+		time.Sleep(sleepDur)
+		rec := <- ch
+		if i > 1 && rec.Key != nil {
+			t.Fatalf("TestCustomIterCh failed: %v: %v", nonNilValErr, rec.Key)
 		}
-	} else {
-		t.Fatalf("TestCustomIterCh failed: %v", generalBoundsErr)
 	}
 
 	params.LowerBound = time.Time{}
 	params.UpperBound = maxTime
 
-	if ch, ok := sm.CustomIterCh(params); ok {
-		for i := 0; i < 5; i++ {
-			time.Sleep(5 * time.Microsecond)
-			rec := <- ch
-			if i > 1 && rec.Key != nil {
-				t.Fatalf("TestCustomIterCh failed: %v: %v", nonNilValErr, rec.Key)
-			}
+	ch = sm.CustomIterCh(params)
+	for i := 0; i < 5; i++ {
+		time.Sleep(sleepDur)
+		rec := <- ch
+		if i > 1 && rec.Key != nil {
+			t.Fatalf("TestCustomIterCh failed: %v: %v", nonNilValErr, rec.Key)
 		}
-	} else {
-		t.Fatalf("TestCustomIterCh failed: %v", generalBoundsErr)
 	}
 
 	params = &IterChParams{
 		Reversed: true,
 		SendTimeout: timeout,
 	}
-	if ch, ok := sm.CustomIterCh(params); ok {
-		for i := 0; i < 5; i++ {
-			time.Sleep(5 * time.Microsecond)
-			rec := <- ch
-			if i > 1 && rec.Key != nil {
-				t.Fatalf("TestCustomIterCh failed: %v: %v", nonNilValErr, rec.Key)
-			}
+	ch = sm.CustomIterCh(params)
+	for i := 0; i < 5; i++ {
+		time.Sleep(sleepDur)
+		rec := <- ch
+		if i > 1 && rec.Key != nil {
+			t.Fatalf("TestCustomIterCh failed: %v: %v", nonNilValErr, rec.Key)
 		}
-	} else {
-		t.Fatalf("TestCustomIterCh failed: %v", generalBoundsErr)
 	}
 
 	params.LowerBound = time.Time{}
 	params.UpperBound = maxTime
 
-	if ch, ok := sm.CustomIterCh(params); ok {
-		for i := 0; i < 5; i++ {
-			time.Sleep(5 * time.Microsecond)
-			rec := <- ch
-			if i > 1 && rec.Key != nil {
-				t.Fatalf("TestCustomIterCh failed: %v: %v", nonNilValErr, rec.Key)
-			}
+	ch = sm.CustomIterCh(params)
+	for i := 0; i < 5; i++ {
+		time.Sleep(sleepDur)
+		rec := <- ch
+		if i > 1 && rec.Key != nil {
+			t.Fatalf("TestCustomIterCh failed: %v: %v", nonNilValErr, rec.Key)
 		}
-	} else {
-		t.Fatalf("TestCustomIterCh failed: %v", generalBoundsErr)
 	}
 }
 
 func TestIterChParamsBounds(t *testing.T) {
 	params := new(IterChParams)
-	if params.Bounds() != nil {
-		t.Fatalf("TestCustomIterCh failed: %v", nonNilValErr)
+	if params.bounds() != nil {
+		t.Fatalf("TestIterChParamsBounds failed: %v", nonNilValErr)
 	}
 	params.LowerBound = 0
-	if params.Bounds() != nil {
-		t.Fatalf("TestCustomIterCh failed: %v", nonNilValErr)
+	if params.bounds() != nil {
+		t.Fatalf("TestIterChParamsBounds failed: %v", nonNilValErr)
 	}
 	params = new(IterChParams)
 	params.UpperBound = 0
-	if params.Bounds() != nil {
-		t.Fatalf("TestCustomIterCh failed: %v", nonNilValErr)
+	if params.bounds() != nil {
+		t.Fatalf("TestIterChParamsBounds failed: %v", nonNilValErr)
 	}
 	params.LowerBound = 0
-	if params.Bounds() == nil {
-		t.Fatalf("TestCustomIterCh failed: %v", nilValErr)
+	if params.bounds() == nil {
+		t.Fatalf("TestIterChParamsBounds failed: %v", nilValErr)
 	}
 }
 
@@ -118,69 +107,31 @@ func TestBoundedIterCh(t *testing.T) {
 	earlierDate := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
 	laterDate := time.Date(5321, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	_, ok := sm.BoundedIterCh(false, nil, nil)
-	if !ok {
-		t.Fatalf("TestBoundedIterCh failed: %v", generalBoundsErr)
-	}
+	if err := verifyRecords(sm.BoundedIterCh(reversed, nil, nil), reversed); err != nil {
+		t.Fatal(err)
+	}	
 
-	ch, ok := sm.BoundedIterCh(false, time.Time{}, time.Time{})
-	if !ok {
-		t.Fatalf("TestBoundedIterCh failed: %v", generalBoundsErr)
-	}
-	if err := verifyRecords(ch, reversed); err != nil {
+	if err := verifyRecords(sm.BoundedIterCh(reversed, time.Time{}, maxTime), reversed); err != nil {
 		t.Fatal(err)
 	}
 
-	ch, ok = sm.BoundedIterCh(false, time.Time{}, maxTime)
-	if !ok {
-		t.Fatalf("TestBoundedIterCh failed: %v", generalBoundsErr)
-	}
-	if err := verifyRecords(ch, reversed); err != nil {
+	if err := verifyRecords(sm.BoundedIterCh(reversed, maxTime, time.Time{}), reversed); err != nil {
 		t.Fatal(err)
 	}
 
-	ch, ok = sm.BoundedIterCh(false, maxTime, time.Time{})
-	if !ok {
-		t.Fatalf("TestBoundedIterCh failed: %v", generalBoundsErr)
-	}
-	if err := verifyRecords(ch, reversed); err != nil {
+	if err := verifyRecords(sm.BoundedIterCh(reversed, earlierDate, time.Now()), reversed); err != nil {
 		t.Fatal(err)
 	}
 
-	ch, ok = sm.BoundedIterCh(false, earlierDate, time.Now())
-	if !ok {
-		t.Fatalf("TestBoundedIterCh failed: %v", generalBoundsErr)
-	}
-	if err := verifyRecords(ch, reversed); err != nil {
+	if err := verifyRecords(sm.BoundedIterCh(reversed, time.Now(), earlierDate), reversed); err != nil {
 		t.Fatal(err)
 	}
 
-	ch, ok = sm.BoundedIterCh(false, time.Now(), earlierDate)
-	if !ok {
-		t.Fatalf("TestBoundedIterCh failed: %v", generalBoundsErr)
-	}
-	if err := verifyRecords(ch, reversed); err != nil {
+	if err := verifyRecords(sm.BoundedIterCh(reversed, time.Now(), laterDate), reversed); err != nil {
 		t.Fatal(err)
 	}
 
-	ch, ok = sm.BoundedIterCh(false, time.Now(), laterDate)
-	if !ok {
-		t.Fatalf("TestBoundedIterCh failed: %v", generalBoundsErr)
-	}
-	if err := verifyRecords(ch, reversed); err != nil {
-		t.Fatal(err)
-	}
-
-	ch, ok = sm.BoundedIterCh(false, laterDate, time.Now())
-	if !ok {
-		t.Fatalf("TestBoundedIterCh failed: %v", generalBoundsErr)
-	}
-
-	ch, ok = sm.BoundedIterCh(false, laterDate, laterDate)
-	if !ok {
-		t.Fatalf("TestBoundedIterCh failed: %v", generalBoundsErr)
-	}
-	if err := verifyRecords(ch, reversed); err != nil {
+	if err := verifyRecords(sm.BoundedIterCh(reversed, laterDate, laterDate), reversed); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -205,12 +156,8 @@ func TestCustomIterCh(t *testing.T) {
 		Reversed: reversed,
 		BufSize: buffSize,
 	}
-	if ch, ok := sm.CustomIterCh(params); ok {
-		if err := verifyRecords(ch, params.Reversed); err != nil {
-			t.Fatal(err)
-		}
-	} else {
-		t.Fatalf("TestCustomIterCh failed: %v", generalBoundsErr)
+	if err := verifyRecords(sm.CustomIterCh(params), params.Reversed); err != nil {
+		t.Fatal(err)
 	}
 
 	params = &IterChParams{
@@ -219,12 +166,8 @@ func TestCustomIterCh(t *testing.T) {
 		LowerBound: earlierDate,
 		UpperBound: laterDate,
 	}
-	if ch, ok := sm.CustomIterCh(params); ok {
-		if err := verifyRecords(ch, reversed); err != nil {
-			t.Fatal(err)
-		}
-	} else {
-		t.Fatalf("TestCustomIterCh failed: %v", generalBoundsErr)
+	if err := verifyRecords(sm.CustomIterCh(params), reversed); err != nil {
+		t.Fatal(err)
 	}
 
 	params = &IterChParams{
@@ -233,12 +176,8 @@ func TestCustomIterCh(t *testing.T) {
 		LowerBound: laterDate,
 		UpperBound: earlierDate,
 	}
-	if ch, ok := sm.CustomIterCh(params); ok {
-		if err := verifyRecords(ch, reversed); err != nil {
-			t.Fatal(err)
-		}
-	} else {
-		t.Fatalf("TestCustomIterCh failed: %v", generalBoundsErr)
+	if err := verifyRecords(sm.CustomIterCh(params), reversed); err != nil {
+		t.Fatal(err)
 	}
 
 	reversed = false
@@ -248,12 +187,8 @@ func TestCustomIterCh(t *testing.T) {
 		LowerBound: laterDate,
 		UpperBound: earlierDate,
 	}
-	if ch, ok := sm.CustomIterCh(params); ok {
-		if err := verifyRecords(ch, reversed); err != nil {
-			t.Fatal(err)
-		}
-	} else {
-		t.Fatalf("TestCustomIterCh failed: %v", generalBoundsErr)
+	if err := verifyRecords(sm.CustomIterCh(params), reversed); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/iter_test.go
+++ b/iter_test.go
@@ -31,7 +31,7 @@ func TestIterChTimeout(t *testing.T) {
 
 	if ch, ok := sm.CustomIterCh(params); ok {
 		for i := 0; i < 5; i++ {
-			time.Sleep(5 * time.Microsecond)
+			time.Sleep(10 * time.Microsecond)
 			rec := <- ch
 			if i > 1 && rec.Key != nil {
 				t.Fatalf("TestCustomIterCh failed: %v: %v", nonNilValErr, rec.Key)

--- a/iter_test.go
+++ b/iter_test.go
@@ -27,9 +27,8 @@ func TestIterChTimeout(t *testing.T) {
 		t.Fatal(err)
 	}
 	timeout := 1 * time.Microsecond
-	params := &IterChParams{
-		SendTimeout: &timeout,
-	}
+	params := &IterChParams{SendTimeout: timeout}
+
 	if ch, ok := sm.CustomIterCh(params); ok {
 		for i := 0; i < 5; i++ {
 			time.Sleep(5 * time.Microsecond)
@@ -59,7 +58,7 @@ func TestIterChTimeout(t *testing.T) {
 
 	params = &IterChParams{
 		Reversed: true,
-		SendTimeout: &timeout,
+		SendTimeout: timeout,
 	}
 	if ch, ok := sm.CustomIterCh(params); ok {
 		for i := 0; i < 5; i++ {


### PR DESCRIPTION
Renamed an unexported method for clarity. Added several more comments on exports. Lengthened sleep time during channel send timeout testing.