### PR TITLE
Update BatchReplaceMap style to BatchInsertMap style. If key already exists in map insert/replace, return an error...

### DIFF
--- a/insert.go
+++ b/insert.go
@@ -32,7 +32,7 @@ func (sm *SortedMap) batchInsertMapWithInterfaceKeys(v interface{}) error {
 
 	for key, val := range m {
 		if !sm.insert(key, val) {
-			return fmt.Errorf("Key already exists: %v", key)
+			return fmt.Errorf("Key already exists: %+v", key)
 		}
 	}
 	return nil
@@ -43,7 +43,7 @@ func (sm *SortedMap) batchInsertMapWithStringKeys(v interface{}) error {
 
 	for key, val := range m {
 		if !sm.insert(key, val) {
-			return fmt.Errorf("Key already exists: %v", key)
+			return fmt.Errorf("Key already exists: %+v", key)
 		}
 	}
 	return nil

--- a/replace.go
+++ b/replace.go
@@ -50,7 +50,8 @@ func (sm *SortedMap) BatchReplaceMap(v interface{}) error {
 
 	case map[string]interface{}:
 		return sm.batchReplaceMapWithStringKeys(v)
-	}
 
-	return fmt.Errorf("%s", unsupportedTypeErr)
+	default:
+		return fmt.Errorf("%s", unsupportedTypeErr)
+	}
 }


### PR DESCRIPTION
containing the inserted key, as the map does not have an order, so a slice of bool values does not make sense in that case, along with the potential type errors from using an interface to support multiple map types to import/replace from.